### PR TITLE
Fix: Remove vscode from nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,24 +34,10 @@
           name = "Frontend development shell";
 
           packages = with pkgs; 
-            let vscodeWithExtensions =
-              vscode-with-extensions.override {
-                vscodeExtensions = with vscode-extensions; [
-                  bbenoist.nix
-                  vscodevim.vim
-                  dbaeumer.vscode-eslint
-                  esbenp.prettier-vscode
-                  formulahendry.auto-rename-tag
-                  yzhang.markdown-all-in-one
-                  astro-build.astro-vscode
-                ];
-              };
-            in
-              [ 
-                vscodeWithExtensions 
-                nodejs-18_x
-                nodePackages.pnpm
-              ];
+            [ 
+              nodejs-18_x
+              nodePackages.pnpm
+            ];
           };
       });
     };


### PR DESCRIPTION
Removes vscode from nix dependencies to avoid duplicate installations