### PR TITLE
fix: Fix mobile wrapping

### DIFF
--- a/src/components/SoftwareIndex.module.css
+++ b/src/components/SoftwareIndex.module.css
@@ -4,6 +4,7 @@
   flex-direction: row;
   align-items: center;
   justify-content: center;
+  flex-wrap: wrap;
   gap: 50px;
   flex-basis: 75px;
 }


### PR DESCRIPTION
Before: Icons would overflow off the page on mobile view
After: Icons wrap properly